### PR TITLE
修复虎牙直播

### DIFF
--- a/huya.py
+++ b/huya.py
@@ -5,21 +5,25 @@ import requests
 import re
 
 
-def get_real_url(rid):
-    room_url = 'https://m.huya.com/' + str(rid)
+def get_real_url(room_id):
+    room_url = 'https://m.huya.com/' + str(room_id)
     header = {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    'User-Agent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Mobile Safari/537.36'
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) '
+                      'Chrome/75.0.3770.100 Mobile Safari/537.36 '
     }
     response = requests.get(url=room_url, headers=header)
-    pattern = r"hasvedio: '([\s\S]*.m3u8)"
+    pattern = r"src=\"([\s\S]*)\" data-setup"
+    pattern2 = r"replay"  # 判断是否是回放
     result = re.findall(pattern, response.text, re.I)
+    if re.search(pattern2, response.text):
+        return result[0]
     if result:
-        real_url = result[0]
-        real_url = re.sub(r'_1200[\s\S]*.m3u8', '.m3u8', result[0])
+        url = re.sub(r'_[\s\S]*.m3u8', '.m3u8', result[0])  # 修改了正则留下了密钥和时间戳
+        url = re.sub(r'hw.hls', 'al.hls', url)  # 华为的源好像比阿里的卡
     else:
-        real_url = '未开播或直播间不存在'
-    return real_url
+        url = '未开播或直播间不存在'
+    return "https:" + url
 
 
 rid = input('请输入虎牙房间号：\n')


### PR DESCRIPTION
虎牙直播源如果没有密钥和时间信息 会出现403禁止访问 且密钥和时间戳每30s刷新一次 不会影响已经在观看的直播 如果能弄清楚密钥的生成方式就再好不过了