### PR TITLE
fix斗鱼小主播报错问题

### DIFF
--- a/douyu.py
+++ b/douyu.py
@@ -45,14 +45,10 @@ class DouYu:
             'auth': auth
         }
         res = self.s.post(url, headers=headers, data=data).json()
-        error = res['error']
-        data = res['data']
-        key = ''
-        if data:
-            rtmp_live = data['rtmp_live']
-            key = re.search(r'(\d{1,7}[0-9a-zA-Z]+)_?\d{0,4}(/playlist|.m3u8)', rtmp_live).group(1)
-        return error, data['rtmp_url'] + '/' + data['rtmp_live']
-        # return error, key
+        if 0 != res['error']:
+            print('error at url:{}\nresponse:{}'.format(url, res))
+            return None
+        return data['rtmp_url'] + '/' + data['rtmp_live']
 
     def get_js(self):
         result = re.search(r'(function ub98484234.*)\s(var.*)', self.res).group()
@@ -74,10 +70,7 @@ class DouYu:
 
         url = 'https://m.douyu.com/api/room/ratestream'
         res = self.s.post(url, params=params).json()['data']
-        key = re.search(r'(\d{1,7}[0-9a-zA-Z]+)_?\d{0,4}(.m3u8|/playlist)', res['url']).group(1)
-
         return res['url']
-        # return key
 
     def get_pc_js(self, cdn='ws-h5'):
         """
@@ -105,24 +98,14 @@ class DouYu:
         params += '&cdn={}&rate={}'.format(cdn, self.live_rate)
         url = 'https://www.douyu.com/lapi/live/getH5Play/{}'.format(self.rid)
         res = self.s.post(url, params=params).json()['data']
-
         return res['rtmp_url'] + '/' + res['rtmp_live']
 
     def get_real_url(self):
         ret = []
-        error, url = self.get_pre()
-        if error == 0:
-            ret.append(url)
-        elif error == 102:
-            raise Exception('房间不存在')
-        elif error == 104:
-            raise Exception('房间未开播')
-        # else:
-        #     key = self.get_js()
+        ret.append(self.get_pre())
         ret.append(self.get_js())
         ret.append(self.get_pc_js())
         return ret
-        # return "http://tx2play1.douyucdn.cn/live/{}.flv?uuid=".format(key)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`https://playweb.douyucdn.cn/lapi/live/hlsH5Preview/`
这个接口小主播会报错，改成报错打print了，列表中显示为None

```
输入斗鱼直播间号：
9841609
输入画质(1流畅；2高清；3超清；4蓝光4M；0蓝光8M或10M)：
0
error at url:https://playweb.douyucdn.cn/lapi/live/hlsH5Preview/9841609
response:{'error': 742017, 'msg': '后端服务异常', 'data': ''}
[None, 'http://hlstct.douyucdn2.cn/dyliveflv3/9841609riqSJyfy9.m3u8?txSecret=9f9c73a84660b5b62bc6d5b606be0d7f&txTime=60bde026&token=h5-douyu-0-9841609-61b467c573a2c72c3dead885fc0ecebe&did=10000000000000000000000000001501&origin=tct&vhost=play3', 'https://tc-tct.douyucdn2.cn/dyliveflv3/9841609riqSJyfy9.flv?wsAuth=7b8705187127ffa912d49b8e8268e45f&token=web-h5-0-9841609-6e154dc2f107837ff9f5cc1836ce8a3ff132fe9fdea98e27&logo=0&expire=0&did=10000000000000000000000000001501&pt=2&st=0&origin=tct&mix=0&isp=']
```