### PR TITLE
修正huya匹配正则，修正虎牙CDN地址

### DIFF
--- a/huya.py
+++ b/huya.py
@@ -23,7 +23,7 @@ class HuYa:
                               '(KHTML, like Gecko) Chrome/75.0.3770.100 Mobile Safari/537.36 '
             }
             response = requests.get(url=room_url, headers=header).text
-            livelineurl = re.findall(r'liveLineUrl = "([\s\S]*?)";', response)[0]
+            livelineurl = re.findall(r'"liveLineUrl":"([\s\S]*?)",', response)[0]
             livelineurl = base64.b64decode(livelineurl).decode('utf-8')
             if livelineurl:
                 if 'replay' in livelineurl:
@@ -32,7 +32,7 @@ class HuYa:
                     }
                 else:
                     stream_name = self.get_stream_name(livelineurl)
-                    base_url = 'http://121.12.115.15/tx.hls.huya.com/src/' + stream_name
+                    base_url = 'http://121.12.115.26/tx.hls.huya.com/src/' + stream_name
                     real_url = {
                         'hls': base_url + '.m3u8',
                         'flv': base_url + '.flv',


### PR DESCRIPTION
m.huya.com中关于liveLineUrl的部分已经修改为json格式，本次对应进行修改，另外将cdn地址修改为新地址。