### PR TITLE
Fix: graceful shutdown client object

### DIFF
--- a/danmu/danmaku/__init__.py
+++ b/danmu/danmaku/__init__.py
@@ -68,7 +68,13 @@ class DanmakuClient:
         self.__hs = aiohttp.ClientSession()
 
     async def init_ws(self):
-        ws_url, reg_datas = await self.__site.get_ws_info(self.__url)
+        try:
+            ws_url, reg_datas = await self.__site.get_ws_info(self.__url)
+        except Exception as e:
+            raise 
+        finally:
+            await self.__hs.close()
+            
         self.__ws = await self.__hs.ws_connect(ws_url)
         if reg_datas:
             for reg_data in reg_datas:


### PR DESCRIPTION
使用过程中遇到一个问题，没有获取到ws链接的话（比如尝试获取时发现未开播），client的__hs未关闭存在内存泄漏。

加入try和finally避免问题。